### PR TITLE
Add quiz CRUD endpoints and BFF quiz proxy with tests and docs

### DIFF
--- a/OpenQuiz.postman_collection.json
+++ b/OpenQuiz.postman_collection.json
@@ -1,0 +1,142 @@
+{
+  "info": {
+    "name": "OpenQuiz BFF",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {"key": "quiz_service", "value": "http://localhost:8000"},
+    {"key": "bff_admin", "value": "http://localhost/admin"}
+  ],
+  "item": [
+    {
+      "name": "Quiz Service",
+      "item": [
+        {
+          "name": "Health",
+          "request": {
+            "method": "GET",
+            "url": "{{quiz_service}}/healthz"
+          }
+        },
+        {
+          "name": "Create Quiz",
+          "request": {
+            "method": "POST",
+            "header": [{"key": "Content-Type", "value": "application/json"}],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"Sample\",\n  \"questions\": []\n}"
+            },
+            "url": "{{quiz_service}}/quizzes"
+          }
+        },
+        {
+          "name": "Get Quiz",
+          "request": {
+            "method": "GET",
+            "url": "{{quiz_service}}/quizzes/:quiz_id"
+          }
+        },
+        {
+          "name": "List Quizzes",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{quiz_service}}/quizzes?limit=10&offset=0",
+              "host": ["{{quiz_service}}"],
+              "path": ["quizzes"],
+              "query": [
+                {"key": "limit", "value": "10"},
+                {"key": "offset", "value": "0"}
+              ]
+            }
+          }
+        },
+        {
+          "name": "Update Quiz",
+          "request": {
+            "method": "PUT",
+            "header": [{"key": "Content-Type", "value": "application/json"}],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"Updated\",\n  \"questions\": []\n}"
+            },
+            "url": "{{quiz_service}}/quizzes/:quiz_id"
+          }
+        },
+        {
+          "name": "Delete Quiz",
+          "request": {
+            "method": "DELETE",
+            "url": "{{quiz_service}}/quizzes/:quiz_id"
+          }
+        }
+      ]
+    },
+    {
+      "name": "BFF Admin",
+      "item": [
+        {
+          "name": "Health",
+          "request": {
+            "method": "GET",
+            "url": "{{bff_admin}}/healthz"
+          }
+        },
+        {
+          "name": "Create Quiz",
+          "request": {
+            "method": "POST",
+            "header": [{"key": "Content-Type", "value": "application/json"}],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"Sample\",\n  \"questions\": []\n}"
+            },
+            "url": "{{bff_admin}}/quizzes"
+          }
+        },
+        {
+          "name": "Get Quiz",
+          "request": {
+            "method": "GET",
+            "url": "{{bff_admin}}/quizzes/:quiz_id"
+          }
+        },
+        {
+          "name": "List Quizzes",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{bff_admin}}/quizzes?limit=10&offset=0",
+              "host": ["{{bff_admin}}"],
+              "path": ["quizzes"],
+              "query": [
+                {"key": "limit", "value": "10"},
+                {"key": "offset", "value": "0"}
+              ]
+            }
+          }
+        },
+        {
+          "name": "Update Quiz",
+          "request": {
+            "method": "PUT",
+            "header": [{"key": "Content-Type", "value": "application/json"}],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"Updated\",\n  \"questions\": []\n}"
+            },
+            "url": "{{bff_admin}}/quizzes/:quiz_id"
+          }
+        },
+        {
+          "name": "Delete Quiz",
+          "request": {
+            "method": "DELETE",
+            "url": "{{bff_admin}}/quizzes/:quiz_id"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# OpenQuiz BFF
+
+Backend para o projeto OpenQuiz, um clone estilo Kahoot com arquitetura **Backend for Frontend** usando FastAPI.
+
+## Rodando o projeto
+
+```bash
+docker compose up --build
+```
+
+Isso inicia os serviços com Traefik, MongoDB e Redis. O BFF Admin fica exposto em `http://localhost/admin`.
+
+## Health check
+
+```bash
+curl http://localhost/admin/healthz
+```
+
+## Exemplo de uso da API
+
+### Criar quiz
+
+```bash
+curl -X POST http://localhost/admin/quizzes \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"Meu Quiz","questions":[]}'
+```
+
+### Listar quizzes
+
+```bash
+curl http://localhost/admin/quizzes
+```
+
+### Buscar quiz por id
+
+```bash
+curl http://localhost/admin/quizzes/ID_DO_QUIZ
+```
+
+### Atualizar quiz
+
+```bash
+curl -X PUT http://localhost/admin/quizzes/ID_DO_QUIZ \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"Quiz Atualizado","questions":[]}'
+```
+
+### Excluir quiz
+
+```bash
+curl -X DELETE http://localhost/admin/quizzes/ID_DO_QUIZ
+```
+
+## Postman
+
+Uma collection Postman com esses endpoints está disponível em [OpenQuiz.postman_collection.json](./OpenQuiz.postman_collection.json).
+

--- a/apps/bff-admin/app/main.py
+++ b/apps/bff-admin/app/main.py
@@ -1,6 +1,6 @@
 import os
 import httpx
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Response
 from common_schemas import Quiz, SessionCreate
 
 UPSTREAM_QUIZ = os.getenv("UPSTREAM_QUIZ", "http://quiz-service:8000")
@@ -8,11 +8,18 @@ UPSTREAM_GAME = os.getenv("UPSTREAM_GAME", "http://game-service:8000")
 
 app = FastAPI(title="bff-admin")
 
-@app.get("/admin/healthz")
+
+@app.get("/healthz", summary="Health check")
+async def root_health():
+    return {"status": "ok"}
+
+
+@app.get("/admin/healthz", summary="Admin health")
 async def health():
     return {"status": "ok"}
 
-@app.post("/admin/quizzes", response_model=Quiz)
+
+@app.post("/admin/quizzes", response_model=Quiz, summary="Create quiz")
 async def create_quiz(payload: Quiz):
     async with httpx.AsyncClient() as client:
         r = await client.post(f"{UPSTREAM_QUIZ}/quizzes", json=payload.model_dump())
@@ -20,7 +27,46 @@ async def create_quiz(payload: Quiz):
             raise HTTPException(r.status_code, r.text)
         return Quiz(**r.json())
 
-@app.post("/admin/sessions")
+
+@app.get("/admin/quizzes/{quiz_id}", response_model=Quiz, summary="Get quiz")
+async def get_quiz(quiz_id: str):
+    async with httpx.AsyncClient() as client:
+        r = await client.get(f"{UPSTREAM_QUIZ}/quizzes/{quiz_id}")
+        if r.status_code != 200:
+            raise HTTPException(r.status_code, r.text)
+        return Quiz(**r.json())
+
+
+@app.get("/admin/quizzes", response_model=list[Quiz], summary="List quizzes")
+async def list_quizzes(limit: int = 10, offset: int = 0):
+    params = {"limit": limit, "offset": offset}
+    async with httpx.AsyncClient() as client:
+        r = await client.get(f"{UPSTREAM_QUIZ}/quizzes", params=params)
+        if r.status_code != 200:
+            raise HTTPException(r.status_code, r.text)
+        return [Quiz(**item) for item in r.json()]
+
+
+@app.put("/admin/quizzes/{quiz_id}", response_model=Quiz, summary="Update quiz")
+async def update_quiz(quiz_id: str, payload: Quiz):
+    async with httpx.AsyncClient() as client:
+        r = await client.put(f"{UPSTREAM_QUIZ}/quizzes/{quiz_id}", json=payload.model_dump())
+        if r.status_code != 200:
+            raise HTTPException(r.status_code, r.text)
+        return Quiz(**r.json())
+
+
+@app.delete("/admin/quizzes/{quiz_id}", summary="Delete quiz")
+async def delete_quiz(quiz_id: str):
+    async with httpx.AsyncClient() as client:
+        r = await client.delete(f"{UPSTREAM_QUIZ}/quizzes/{quiz_id}")
+        if r.status_code != 200:
+            raise HTTPException(r.status_code, r.text)
+        if r.content:
+            return r.json()
+        return Response(status_code=r.status_code)
+
+@app.post("/admin/sessions", summary="Create session")
 async def create_session(payload: SessionCreate):
     async with httpx.AsyncClient() as client:
         r = await client.post(f"{UPSTREAM_GAME}/sessions", json=payload.model_dump())
@@ -28,7 +74,7 @@ async def create_session(payload: SessionCreate):
             raise HTTPException(r.status_code, r.text)
         return r.json()
 
-@app.post("/admin/sessions/{session_id}/start")
+@app.post("/admin/sessions/{session_id}/start", summary="Start session")
 async def start_session(session_id: str):
     async with httpx.AsyncClient() as client:
         r = await client.post(f"{UPSTREAM_GAME}/sessions/{session_id}/start")

--- a/services/quiz-service/app/main.py
+++ b/services/quiz-service/app/main.py
@@ -1,22 +1,31 @@
 from fastapi import FastAPI, HTTPException
+from fastapi import Query
 from bson import ObjectId
 from common_schemas import Quiz
 from .db import db
 
 app = FastAPI(title="quiz-service")
 
-@app.get("/healthz")
+
+@app.on_event("startup")
+async def create_indexes():
+    await db.quizzes.create_index("title")
+
+
+@app.get("/healthz", summary="Health check")
 async def health():
     return {"status": "ok"}
 
-@app.post("/quizzes", response_model=Quiz)
+
+@app.post("/quizzes", response_model=Quiz, summary="Create quiz")
 async def create_quiz(payload: Quiz):
     data = payload.model_dump()
     res = await db.quizzes.insert_one(data)
     data["id"] = str(res.inserted_id)
     return Quiz(**data)
 
-@app.get("/quizzes/{quiz_id}", response_model=Quiz)
+
+@app.get("/quizzes/{quiz_id}", response_model=Quiz, summary="Get quiz")
 async def get_quiz(quiz_id: str):
     try:
         _id = ObjectId(quiz_id)
@@ -27,3 +36,40 @@ async def get_quiz(quiz_id: str):
         raise HTTPException(404, "quiz not found")
     doc["id"] = str(doc.pop("_id"))
     return Quiz(**doc)
+
+
+@app.get("/quizzes", response_model=list[Quiz], summary="List quizzes")
+async def list_quizzes(limit: int = Query(10, ge=1), offset: int = Query(0, ge=0)):
+    cursor = db.quizzes.find().skip(offset).limit(limit)
+    quizzes = []
+    async for doc in cursor:
+        doc["id"] = str(doc.pop("_id"))
+        quizzes.append(Quiz(**doc))
+    return quizzes
+
+
+@app.put("/quizzes/{quiz_id}", response_model=Quiz, summary="Update quiz")
+async def update_quiz(quiz_id: str, payload: Quiz):
+    try:
+        _id = ObjectId(quiz_id)
+    except Exception:
+        raise HTTPException(400, "invalid id")
+    data = payload.model_dump(exclude={"id"})
+    updated = await db.quizzes.update_one({"_id": _id}, {"$set": data})
+    if not updated.matched_count:
+        raise HTTPException(404, "quiz not found")
+    doc = await db.quizzes.find_one({"_id": _id})
+    doc["id"] = str(doc.pop("_id"))
+    return Quiz(**doc)
+
+
+@app.delete("/quizzes/{quiz_id}", summary="Delete quiz")
+async def delete_quiz(quiz_id: str):
+    try:
+        _id = ObjectId(quiz_id)
+    except Exception:
+        raise HTTPException(400, "invalid id")
+    res = await db.quizzes.delete_one({"_id": _id})
+    if not res.deleted_count:
+        raise HTTPException(404, "quiz not found")
+    return {"status": "deleted"}

--- a/tests/bff_admin/test_quizzes_proxy.py
+++ b/tests/bff_admin/test_quizzes_proxy.py
@@ -1,0 +1,80 @@
+import sys
+import pathlib
+import pytest
+import pytest_asyncio
+import httpx
+from mongomock_motor import AsyncMongoMockClient
+import importlib.util
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+COMMON_PATH = ROOT / "packages" / "common_schemas"
+QUIZ_SERVICE_PATH = ROOT / "services" / "quiz-service"
+BFF_PATH = ROOT / "apps" / "bff-admin"
+
+sys.path.extend([str(COMMON_PATH), str(QUIZ_SERVICE_PATH)])
+
+from app import main as quiz_main  # type: ignore  # noqa: E402
+from app import db as quiz_db  # type: ignore  # noqa: E402
+
+spec = importlib.util.spec_from_file_location("bff_main", BFF_PATH / "app" / "main.py")
+bff_main = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bff_main)
+
+
+@pytest_asyncio.fixture
+async def client(monkeypatch):
+    client_db = AsyncMongoMockClient()
+    quiz_db.db = client_db["testdb"]
+    quiz_main.db = quiz_db.db
+
+    class PatchedAsyncClient(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs.setdefault("app", quiz_main.app)
+            kwargs.setdefault("base_url", "http://quiz-service:8000")
+            return super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(bff_main.httpx, "AsyncClient", PatchedAsyncClient)
+    monkeypatch.setattr(bff_main, "UPSTREAM_QUIZ", "http://quiz-service:8000")
+
+    async with httpx.AsyncClient(app=bff_main.app, base_url="http://test") as client:
+        yield client
+
+
+def sample_quiz(title="Sample Quiz"):
+    return {
+        "title": title,
+        "questions": [
+            {
+                "id": "q1",
+                "text": "1+1?",
+                "options": ["1", "2"],
+                "correct": [1],
+                "time_limit_s": 20,
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_proxy_crud(client):
+    resp = await client.post("/admin/quizzes", json=sample_quiz())
+    assert resp.status_code == 200
+    quiz_id = resp.json()["id"]
+
+    resp = await client.get(f"/admin/quizzes/{quiz_id}")
+    assert resp.status_code == 200
+
+    payload = sample_quiz("Updated Quiz")
+    resp = await client.put(f"/admin/quizzes/{quiz_id}", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Updated Quiz"
+
+    resp = await client.get("/admin/quizzes", params={"limit": 10, "offset": 0})
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    resp = await client.delete(f"/admin/quizzes/{quiz_id}")
+    assert resp.status_code == 200
+
+    resp = await client.get(f"/admin/quizzes/{quiz_id}")
+    assert resp.status_code == 404

--- a/tests/quiz_service/test_quizzes.py
+++ b/tests/quiz_service/test_quizzes.py
@@ -1,0 +1,71 @@
+import sys
+import pathlib
+import sys
+import pytest
+import pytest_asyncio
+import httpx
+from mongomock_motor import AsyncMongoMockClient
+
+# Add paths for quiz-service and shared schemas
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SERVICE_PATH = ROOT / "services" / "quiz-service"
+COMMON_PATH = ROOT / "packages" / "common_schemas"
+sys.path.extend([str(SERVICE_PATH), str(COMMON_PATH)])
+
+from app import main as quiz_main
+from app import db as quiz_db
+
+
+@pytest_asyncio.fixture
+async def client():
+    # use in-memory mongo
+    client = AsyncMongoMockClient()
+    quiz_db.db = client["testdb"]
+    quiz_main.db = quiz_db.db
+    async with httpx.AsyncClient(app=quiz_main.app, base_url="http://test") as client:
+        yield client
+
+
+def sample_quiz(title="Sample Quiz"):
+    return {
+        "title": title,
+        "questions": [
+            {
+                "id": "q1",
+                "text": "1+1?",
+                "options": ["1", "2"],
+                "correct": [1],
+                "time_limit_s": 20,
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_crud_cycle(client):
+    # create
+    resp = await client.post("/quizzes", json=sample_quiz())
+    assert resp.status_code == 200
+    data = resp.json()
+    quiz_id = data["id"]
+
+    # read
+    resp = await client.get(f"/quizzes/{quiz_id}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == quiz_id
+
+    # update
+    payload = sample_quiz("Updated Quiz")
+    resp = await client.put(f"/quizzes/{quiz_id}", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Updated Quiz"
+
+    # list
+    resp = await client.get("/quizzes", params={"limit": 10, "offset": 0})
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    # delete
+    resp = await client.delete(f"/quizzes/{quiz_id}")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "deleted"


### PR DESCRIPTION
## Summary
- implement full quiz CRUD with listing, update, delete, and index creation
- add bff-admin pass-through routes and health checks
- cover quiz service and proxy behaviour with tests
- document curl usage and provide Postman collection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb48a95da4832e80c90d87634877e7