### PR TITLE
Fix Traefik routing by enabling Docker provider

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       - --entrypoints.web.address=:80
       - --entrypoints.websecure.address=:443
       - --entrypoints.h3.address=:443/udp
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
       - --providers.file.directory=/etc/traefik/dynamic
       - --providers.file.watch=true
     ports:
@@ -15,6 +17,7 @@ services:
     volumes:
       - ./infra/traefik/traefik.yml:/etc/traefik/traefik.yml:ro
       - ./infra/traefik/dynamic:/etc/traefik/dynamic:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     depends_on:
       - bff-admin
       - bff-player


### PR DESCRIPTION
## Summary
- expose Docker provider in Traefik and mount docker socket to allow routing based on service labels

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb52428e18832e8d18fb9d49d6d127