### PR TITLE
Implement session lifecycle and admin proxies

### DIFF
--- a/apps/bff-admin/app/routes/sessions.py
+++ b/apps/bff-admin/app/routes/sessions.py
@@ -24,3 +24,30 @@ async def start_session(session_id: str):
         if r.status_code != 200:
             raise HTTPException(r.status_code, r.text)
         return r.json()
+
+
+@router.post("/admin/sessions/{session_id}/next", summary="Next question")
+async def next_question(session_id: str):
+    async with httpx.AsyncClient() as client:
+        r = await client.post(f"{UPSTREAM_GAME}/sessions/{session_id}/next")
+        if r.status_code != 200:
+            raise HTTPException(r.status_code, r.text)
+        return r.json()
+
+
+@router.post("/admin/sessions/{session_id}/end", summary="End session")
+async def end_session(session_id: str):
+    async with httpx.AsyncClient() as client:
+        r = await client.post(f"{UPSTREAM_GAME}/sessions/{session_id}/end")
+        if r.status_code != 200:
+            raise HTTPException(r.status_code, r.text)
+        return r.json()
+
+
+@router.get("/admin/sessions/{session_id}", summary="Get session")
+async def get_session(session_id: str):
+    async with httpx.AsyncClient() as client:
+        r = await client.get(f"{UPSTREAM_GAME}/sessions/{session_id}")
+        if r.status_code != 200:
+            raise HTTPException(r.status_code, r.text)
+        return r.json()

--- a/services/game-service/app/main.py
+++ b/services/game-service/app/main.py
@@ -20,6 +20,22 @@ async def health():
 class SessionOut(SessionState):
     pin: str
 
+@app.get("/sessions/{session_id}", response_model=SessionOut)
+async def get_session(session_id: str):
+    try:
+        _id = ObjectId(session_id)
+    except Exception:
+        raise HTTPException(400, "invalid id")
+    s = await db.sessions.find_one({"_id": _id})
+    if not s:
+        raise HTTPException(404, "session not found")
+    return SessionOut(
+        session_id=session_id,
+        state=s.get("state", "lobby"),
+        current_q_idx=int(s.get("current_q_idx", 0)),
+        pin=s.get("pin", ""),
+    )
+
 @app.post("/sessions", response_model=SessionOut)
 async def create_session(payload: SessionCreate):
     pin = str(random.randint(100000, 999999))

--- a/tests/bff_admin/test_sessions_flow.py
+++ b/tests/bff_admin/test_sessions_flow.py
@@ -1,0 +1,138 @@
+import sys
+import pathlib
+import types
+import pytest
+import pytest_asyncio
+import httpx
+from mongomock_motor import AsyncMongoMockClient
+import importlib.util
+import importlib
+from types import SimpleNamespace
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+COMMON_PATH = ROOT / "packages" / "common_schemas"
+QUIZ_SERVICE_PATH = ROOT / "services" / "quiz-service" / "app"
+GAME_SERVICE_PATH = ROOT / "services" / "game-service" / "app"
+BFF_PATH = ROOT / "apps" / "bff-admin" / "app"
+
+sys.path.extend([str(COMMON_PATH)])
+
+
+def load_service(path: pathlib.Path, pkg_name: str):
+    pkg = types.ModuleType(pkg_name)
+    pkg.__path__ = [str(path)]
+    sys.modules[pkg_name] = pkg
+    spec = importlib.util.spec_from_file_location(f"{pkg_name}.main", path / "main.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[f"{pkg_name}.main"] = module
+    spec.loader.exec_module(module)
+    return module
+
+quiz_main = load_service(QUIZ_SERVICE_PATH, "quiz_service_app")
+quiz_db = quiz_main.db
+
+game_main = load_service(GAME_SERVICE_PATH, "game_service_app")
+
+bff_main = load_service(BFF_PATH, "bff_admin_app")
+quizzes_module = importlib.import_module("bff_admin_app.routes.quizzes")
+sessions_module = importlib.import_module("bff_admin_app.routes.sessions")
+
+
+@pytest_asyncio.fixture
+async def client(monkeypatch):
+    qclient = AsyncMongoMockClient()
+    quiz_db.db = qclient["testdb"]
+    quiz_main.db = quiz_db.db
+
+    gclient = AsyncMongoMockClient()
+    game_main.db = gclient["testdb"]
+
+    class FakeRedis:
+        def __init__(self):
+            self.store = {}
+        async def setex(self, key, ttl, value):
+            self.store[key] = {"ttl": ttl, "value": value}
+        async def ping(self):
+            return True
+    fake_redis = FakeRedis()
+    published = []
+    async def fake_publish(room, event):
+        published.append((room, event))
+    monkeypatch.setattr(game_main, "redis", fake_redis)
+    monkeypatch.setattr(game_main, "publish", fake_publish)
+
+    class PatchedQuizClient(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs.setdefault("app", quiz_main.app)
+            kwargs.setdefault("base_url", "http://quiz-service:8000")
+            super().__init__(*args, **kwargs)
+
+    class PatchedGameClient(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs.setdefault("app", game_main.app)
+            kwargs.setdefault("base_url", "http://game-service:8000")
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(quizzes_module, "httpx", SimpleNamespace(AsyncClient=PatchedQuizClient))
+    monkeypatch.setattr(quizzes_module, "UPSTREAM_QUIZ", "http://quiz-service:8000")
+    monkeypatch.setattr(sessions_module, "httpx", SimpleNamespace(AsyncClient=PatchedGameClient))
+    monkeypatch.setattr(sessions_module, "UPSTREAM_GAME", "http://game-service:8000")
+
+    async with httpx.AsyncClient(app=bff_main.app, base_url="http://test") as client:
+        client.fake_redis = fake_redis
+        client.published = published
+        client.pin_prefix = game_main.PIN_PREFIX
+        yield client
+
+
+def sample_quiz(title="Sample Quiz"):
+    return {
+        "title": title,
+        "questions": [
+            {
+                "id": "q1",
+                "text": "1+1?",
+                "options": ["1", "2"],
+                "correct": [1],
+                "time_limit_s": 20,
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_session_flow(client):
+    resp = await client.post("/admin/quizzes", json=sample_quiz())
+    assert resp.status_code == 200
+    quiz_id = resp.json()["id"]
+
+    resp = await client.post("/admin/sessions", json={"quiz_id": quiz_id})
+    assert resp.status_code == 200
+    data = resp.json()
+    session_id = data["session_id"]
+    pin = data["pin"]
+    key = client.pin_prefix + pin
+    assert client.fake_redis.store[key]["ttl"] == 3600
+
+    resp = await client.post(f"/admin/sessions/{session_id}/start")
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "question"
+
+    resp = await client.post(f"/admin/sessions/{session_id}/next")
+    assert resp.status_code == 200
+    assert resp.json()["current_q_idx"] == 1
+
+    resp = await client.post(f"/admin/sessions/{session_id}/end")
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "ended"
+
+    resp = await client.get(f"/admin/sessions/{session_id}")
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "ended"
+
+    assert client.published == [
+        (session_id, {"type": "lobby", "session_id": session_id}),
+        (session_id, {"type": "question", "idx": 0}),
+        (session_id, {"type": "question", "idx": 1}),
+        (session_id, {"type": "ended"}),
+    ]


### PR DESCRIPTION
## Summary
- Expose full session management in game-service with GET, start, next and end operations
- Proxy session management endpoints through bff-admin
- Add integration test covering happy path and Redis event publication

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb7cb8b870832ea27379e6f74a0fa3