### PR TITLE
feat(admin): add full quiz builder

### DIFF
--- a/frontends/admin/i18n/en-US.json
+++ b/frontends/admin/i18n/en-US.json
@@ -7,6 +7,9 @@
     "new": "New Quiz",
     "question": "Question",
     "answer": "Answer",
-    "add_question": "Add question"
+    "add_question": "Add question",
+    "time_limit": "Time (s)",
+    "seconds": "Seconds",
+    "correct": "Correct"
   }
 }

--- a/frontends/admin/i18n/pt-BR.json
+++ b/frontends/admin/i18n/pt-BR.json
@@ -7,6 +7,9 @@
     "new": "Novo Quiz",
     "question": "Pergunta",
     "answer": "Resposta",
-    "add_question": "Adicionar pergunta"
+    "add_question": "Adicionar pergunta",
+    "time_limit": "Tempo (s)",
+    "seconds": "Segundos",
+    "correct": "Correta"
   }
 }

--- a/frontends/admin/src/app/quizzes/new/page.tsx
+++ b/frontends/admin/src/app/quizzes/new/page.tsx
@@ -4,21 +4,133 @@ import { useTranslation } from "react-i18next";
 import { useRouter } from "next/navigation";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { useForm, useFieldArray } from "react-hook-form";
+import { PlusIcon, MinusIcon } from "lucide-react";
+import {
+  useForm,
+  useFieldArray,
+  type Control,
+  type UseFormRegister,
+} from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { fetchJson } from "@/libs/api";
-const questionSchema = z.object({
-  question: z.string().min(1),
-  answer: z.string().min(1),
+
+const answerSchema = z.object({
+  text: z.string().min(1),
 });
+
+const questionSchema = z
+  .object({
+    text: z.string().min(1),
+    time_limit_s: z.number().int().min(10).max(60),
+    options: z.array(answerSchema).min(2).max(5),
+    correct: z.number().int(),
+  })
+  .refine((q) => q.correct >= 0 && q.correct < q.options.length, {
+    message: "Correct answer must be one of the options",
+    path: ["correct"],
+  });
 
 const schema = z.object({
   title: z.string().min(1),
-  questions: z.array(questionSchema).min(1),
+  questions: z.array(questionSchema).min(2).max(20),
 });
 
 type QuizForm = z.infer<typeof schema>;
+
+type QuestionFieldsProps = {
+  index: number;
+  control: Control<QuizForm>;
+  register: UseFormRegister<QuizForm>;
+  t: (key: string) => string;
+  removeQuestion: (index: number) => void;
+};
+
+function QuestionFields({ index, control, register, t, removeQuestion }: QuestionFieldsProps) {
+  const {
+    fields: answers,
+    append: appendAnswer,
+    remove: removeAnswer,
+  } = useFieldArray({
+    control,
+    name: `questions.${index}.options` as const,
+  });
+
+  return (
+    <div className="space-y-4 rounded-lg border p-4">
+      <div className="flex items-start gap-2">
+        <Input
+          placeholder={t("quiz.question")}
+          className="flex-grow"
+          {...register(`questions.${index}.text` as const)}
+        />
+        <div className="flex items-center gap-2">
+          <Input
+            type="number"
+            min={10}
+            max={60}
+            className="w-20"
+            {...register(`questions.${index}.time_limit_s` as const, {
+              valueAsNumber: true,
+            })}
+          />
+          <span className="text-sm text-muted-foreground">
+            {t("quiz.seconds")}
+          </span>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          onClick={() => removeQuestion(index)}
+        >
+          <MinusIcon className="size-4" />
+        </Button>
+      </div>
+      <div className="space-y-2">
+        {answers.map((ansField, ansIndex) => (
+          <div key={ansField.id} className="flex items-center gap-2">
+            <Input
+              className="flex-grow"
+              placeholder={t("quiz.answer")}
+              {...register(`questions.${index}.options.${ansIndex}.text` as const)}
+            />
+            <input
+              type="radio"
+              value={ansIndex}
+              {...register(`questions.${index}.correct` as const, {
+                valueAsNumber: true,
+              })}
+              aria-label={t("quiz.correct")}
+            />
+          </div>
+        ))}
+        <div className="flex gap-2 pt-2">
+          {answers.length < 5 && (
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              onClick={() => appendAnswer({ text: "" })}
+            >
+              <PlusIcon className="size-4" />
+            </Button>
+          )}
+          {answers.length > 2 && (
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              onClick={() => removeAnswer(answers.length - 1)}
+            >
+              <MinusIcon className="size-4" />
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export default function NewQuizPage() {
   const { t } = useTranslation();
@@ -26,11 +138,18 @@ export default function NewQuizPage() {
   const { register, handleSubmit, control } = useForm<QuizForm>({
     resolver: zodResolver(schema),
     defaultValues: {
-      questions: [{ question: "", answer: "" }],
+      questions: [
+        {
+          text: "",
+          time_limit_s: 20,
+          options: [{ text: "" }, { text: "" }],
+          correct: 0,
+        },
+      ],
     },
   });
 
-  const { fields, append } = useFieldArray({
+  const { fields, append, remove } = useFieldArray({
     control,
     name: "questions",
   });
@@ -38,12 +157,12 @@ export default function NewQuizPage() {
   const onSubmit = handleSubmit(async (data) => {
     const payload = {
       title: data.title,
-      questions: data.questions.map((q) => ({
+      questions: data.questions.map((q: QuizForm["questions"][number]) => ({
         id: crypto.randomUUID(),
-        text: q.question,
-        options: [q.answer],
-        correct: [0],
-        time_limit_s: 20,
+        text: q.text,
+        options: q.options.map((o: { text: string }) => o.text),
+        correct: [q.correct],
+        time_limit_s: q.time_limit_s,
       })),
     };
     try {
@@ -58,34 +177,36 @@ export default function NewQuizPage() {
   });
 
   return (
-    <form onSubmit={onSubmit} className="p-4 max-w-md space-y-4">
-      <div>
-        <label className="block mb-1">{t("quiz.title")}</label>
-        <Input {...register("title")} />
-      </div>
+    <form onSubmit={onSubmit} className="p-4 space-y-4">
+      <Input placeholder={t("quiz.title")} {...register("title")} />
       <div className="space-y-4">
         {fields.map((field, index) => (
-          <div key={field.id} className="space-y-2">
-            <div>
-              <label className="block mb-1">
-                {t("quiz.question")} #{index + 1}
-              </label>
-              <Input {...register(`questions.${index}.question` as const)} />
-            </div>
-            <div>
-              <label className="block mb-1">{t("quiz.answer")}</label>
-              <Input {...register(`questions.${index}.answer` as const)} />
-            </div>
-          </div>
+          <QuestionFields
+            key={field.id}
+            index={index}
+            control={control}
+            register={register}
+            t={t}
+            removeQuestion={remove}
+          />
         ))}
+      </div>
+      {fields.length < 20 && (
         <Button
           type="button"
           variant="outline"
-          onClick={() => append({ question: "", answer: "" })}
+          onClick={() =>
+            append({
+              text: "",
+              time_limit_s: 20,
+              options: [{ text: "" }, { text: "" }],
+              correct: 0,
+            })
+          }
         >
           {t("quiz.add_question")}
         </Button>
-      </div>
+      )}
       <Button type="submit">{t("quiz.new")}</Button>
     </form>
   );


### PR DESCRIPTION
## Summary
- build quiz form supporting up to 20 questions and 5 answers each
- add per-question time limits and correct-answer radio selector
- localize new time and correct labels in English and Portuguese
- streamline layout with card sections, seconds label, and icon buttons

## Testing
- `npm run lint`
- `npm run typecheck`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbae5d74c4832ebefbb5db3a883294